### PR TITLE
Dispatch observer notifications on MainActor

### DIFF
--- a/Decide/Environment/Observation.swift
+++ b/Decide/Environment/Observation.swift
@@ -24,9 +24,11 @@ class ObservationSystem {
     func valueDidChange() {
         let observers = storage
         storage = []
-        observers.forEach { observer in
-            observer.objectWillChange.send()
-        }
+        Task { await MainActor.run {
+            observers.forEach { observer in
+                observer.objectWillChange.send()
+            }
+        }}
     }
 }
 


### PR DESCRIPTION
Since observers are notified within the state update, which also might be initiated by the view, we need to make sure they are run separately since it can cause undefined behavior and possible infinite loops.
