### PR TITLE
Initial: Telemetry/Tracing interface

### DIFF
--- a/Decide/Accessor/Default/DefaultBind.swift
+++ b/Decide/Accessor/Default/DefaultBind.swift
@@ -20,11 +20,16 @@ import Foundation
     @DefaultEnvironment var environment
 
     private let propertyKeyPath: KeyPath<S, Property<Value>>
+    let context: Context
 
     public init(
-        _ keyPath: KeyPath<S, Mutable<Value>>
+        _ keyPath: KeyPath<S, Mutable<Value>>,
+        file: String = #fileID,
+        line: Int = #line
     ) {
-        propertyKeyPath = keyPath.appending(path: \.wrappedValue)
+        let context = Context(file: file, line: line)
+        self.context = context
+        self.propertyKeyPath = keyPath.appending(path: \.wrappedValue)
     }
 
     public static subscript<EnclosingObject: EnvironmentObservingObject>(
@@ -46,6 +51,7 @@ import Foundation
             let environment = instance.environment
             storage.environment = environment
             environment.setValue(newValue, propertyKeyPath)
+            environment.telemetry.log(event: UnstructuredMutation(context: storage.context, keyPath: "\(propertyKeyPath)", value: newValue))
         }
     }
     

--- a/Decide/Accessor/SwiftUI/Bind.swift
+++ b/Decide/Accessor/SwiftUI/Bind.swift
@@ -20,10 +20,13 @@ import SwiftUI
 @MainActor public struct Bind<S: AtomicState, Value>: DynamicProperty {
     @SwiftUI.Environment(\.stateEnvironment) var environment
     @ObservedObject var observer = ObservedObjectWillChangeNotification()
+    let context: Context
 
     let propertyKeyPath: KeyPath<S, Property<Value>>
 
-    public init(_ propertyKeyPath: KeyPath<S, Mutable<Value>>) {
+    public init(_ propertyKeyPath: KeyPath<S, Mutable<Value>>, file: String = #fileID, line: Int = #line) {
+        let context = Context(file: file, line: line)
+        self.context = context
         self.propertyKeyPath = propertyKeyPath.appending(path: \.wrappedValue)
     }
 
@@ -34,6 +37,7 @@ import SwiftUI
         }
         nonmutating set {
             environment.setValue(newValue, propertyKeyPath)
+            environment.telemetry.log(event: UnstructuredMutation(context: context, keyPath: "\(propertyKeyPath)", value: newValue))
         }
     }
 

--- a/Decide/Accessor/SwiftUI/BindKeyed.swift
+++ b/Decide/Accessor/SwiftUI/BindKeyed.swift
@@ -20,10 +20,14 @@ import SwiftUI
 
     @SwiftUI.Environment(\.stateEnvironment) var environment
     @ObservedObject var observer = ObservedObjectWillChangeNotification()
+    let context: Context
+
 
     let propertyKeyPath: KeyPath<S, Property<Value>>
 
-    public init(_ propertyKeyPath: KeyPath<S, Mutable<Value>>) {
+    public init(_ propertyKeyPath: KeyPath<S, Mutable<Value>>, file: String = #fileID, line: Int = #line) {
+        let context = Context(file: file, line: line)
+        self.context = context
         self.propertyKeyPath = propertyKeyPath.appending(path: \.wrappedValue)
     }
 
@@ -37,7 +41,8 @@ import SwiftUI
                 return environment.getValue(propertyKeyPath, at: identifier)
             },
             set: {
-                return environment.setValue($0, propertyKeyPath, at: identifier)
+                environment.setValue($0, propertyKeyPath, at: identifier)
+                environment.telemetry.log(event: UnstructuredMutation(context: context, keyPath: "\(propertyKeyPath):\(identifier)", value: $0))
             }
         )
     }

--- a/Decide/Environment/Environment.swift
+++ b/Decide/Environment/Environment.swift
@@ -28,6 +28,21 @@ import Foundation
     static let `default` = ApplicationEnvironment()
 
     var storage: [Key: Any] = [:]
+    let telemetry: Telemetry = {
+        guard let config = ProcessInfo
+            .processInfo
+            .environment["DECIDE_TRACER"]
+        else {
+            return Telemetry(observer: OSLogTelemetryObserver()) // .noTelemetry 
+        }
+
+        if config.replacingOccurrences(of: " ", with: "").lowercased() == "oslog" {
+            return Telemetry(observer: OSLogTelemetryObserver())
+        }
+
+        // OSLog by default
+        return Telemetry(observer: OSLogTelemetryObserver()) // .noTelemetry
+    }()
 
     subscript<S: ValueContainerStorage>(_ key: Key) -> S {
         if let state = storage[key] as? S { return state }

--- a/Decide/Telemetry/Context.swift
+++ b/Decide/Telemetry/Context.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Decide package open source project
+//
+// Copyright (c) 2020-2023 Maxim Bazarov and the Decide package
+// open source project authors
+// Licensed under MIT
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// While enabling extreme modularity by decoupling components,
+/// we must not loose the context of execution while debugging
+/// or dealing with incidents.
+///
+/// Decide guaranties that every state mutation whether it's structured
+/// or unstructured can be traced to the point of changes origin.
+///
+/// `Context` represents this origin of the change by storing the information about
+/// the point of execution e.g. class or function
+/// as well as the location in the source code.
+///
+public final class Context: Sendable {
+
+    /// The file path where the execution happened.
+    public let file: String
+
+    /// The line number where the execution happened.
+    public let line: Int
+
+    public init(file: String = #fileID, line: Int = #line) {
+        self.file = file
+        self.line = line
+    }
+}
+
+extension Context: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        "\(file):\(line)"
+    }
+}

--- a/Decide/Telemetry/Events/UnstructuredMutation.swift
+++ b/Decide/Telemetry/Events/UnstructuredMutation.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Decide package open source project
+//
+// Copyright (c) 2020-2023 Maxim Bazarov and the Decide package
+// open source project authors
+// Licensed under MIT
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import OSLog
+
+final class UnstructuredMutation<V>: TelemetryEvent {
+    let category: String = "Unstructured State Mutation"
+    let name: String = "Property updated:"
+    let logLevel: OSLogType = .debug
+    let context: Decide.Context
+
+    let keyPath: String
+    let value: V
+
+    init(context: Decide.Context, keyPath: String, value: V) {
+        self.keyPath = keyPath
+        self.context = context
+        self.value = value
+    }
+
+    func message() -> String {
+        "\(keyPath) -> \(String(reflecting: value))"
+    }
+}

--- a/Decide/Telemetry/LoggerObserver.swift
+++ b/Decide/Telemetry/LoggerObserver.swift
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Decide package open source project
+//
+// Copyright (c) 2020-2023 Maxim Bazarov and the Decide package
+// open source project authors
+// Licensed under MIT
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import OSLog
+
+final class OSLogTelemetryObserver: TelemetryObserver {
+
+    static let subsystem = "State and Side-effects (Decide)"
+
+    static let unsafeTracingEnabled: Bool = {
+        guard let config: String = ProcessInfo
+            .processInfo
+            .environment["DECIDE_UNSAFE_TRACING_ENABLED"]
+        else {
+            return false
+        }
+
+        if let intValue = Int(config) {
+            return intValue == 1 ? true : false
+        }
+
+        if config.replacingOccurrences(of: " ", with: "").lowercased() == "true" {
+            return true
+        }
+
+        if config.replacingOccurrences(of: " ", with: "").lowercased() == "yes" {
+            return true
+        }
+
+        return false
+    }()
+
+    func eventDidOccur<E>(_ event: E) where E : TelemetryEvent {
+        let logger = Logger(subsystem: Self.subsystem, category: event.category)
+        if Self.unsafeTracingEnabled {
+            unsafeTrace(event: event, logger: logger)
+        } else {
+            trace(event: event, logger: logger)
+        }
+
+    }
+
+    func trace<E>(event: E, logger: Logger) where E : TelemetryEvent {
+        switch event.logLevel {
+        case .debug:
+            logger.debug("\(event.name): \(event.message(), privacy: .sensitive)\n context: \(event.context.debugDescription)")
+        case .info:
+            logger.info("\(event.message(), privacy: .sensitive)")
+        case .error:
+            logger.error("\(event.message(), privacy: .sensitive)")
+        case .fault:
+            logger.fault("\(event.message(), privacy: .sensitive)")
+        default:
+            logger.log("\(event.message(), privacy: .sensitive)")
+        }
+    }
+
+    func unsafeTrace<E>(event: E, logger: Logger) where E : TelemetryEvent {
+        switch event.logLevel {
+        case .debug:
+            logger.debug("\(event.name): \(event.message(), privacy: .sensitive)\n context: \(event.context.debugDescription)")
+        case .info:
+            logger.info("\(event.message(), privacy: .public)")
+        case .error:
+            logger.error("\(event.message(), privacy: .public)")
+        case .fault:
+            logger.fault("\(event.message(), privacy: .public)")
+        default:
+            logger.log("\(event.message(), privacy: .public)")
+        }
+    }
+}
+
+

--- a/Decide/Telemetry/Telemetry.swift
+++ b/Decide/Telemetry/Telemetry.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Decide package open source project
+//
+// Copyright (c) 2020-2023 Maxim Bazarov and the Decide package
+// open source project authors
+// Licensed under MIT
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import OSLog
+
+final class Telemetry {
+
+    /// Minimum log level to log.
+    /// [Choose the Appropriate Log Level for Each Message](https://developer.apple.com/documentation/os/logging/generating_log_messages_from_your_code#3665947)
+    var logLevel: OSLogType = .default
+
+    let observer: TelemetryObserver
+
+    init(observer: TelemetryObserver) {
+        self.observer = observer
+    }
+
+    func log<E: TelemetryEvent>(event: E) {
+        guard event.logLevel.rawValue >= self.logLevel.rawValue
+        else { return }
+        observer.eventDidOccur(event)
+    }
+}
+
+final class DoNotObserve: TelemetryObserver {
+    func eventDidOccur<E>(_ event: E) where E : TelemetryEvent {}
+}
+extension Telemetry {
+    static let noTelemetry = Telemetry(observer: DoNotObserve())
+}
+
+/// [Choose the Appropriate Log Level for Each Message](https://developer.apple.com/documentation/os/logging/generating_log_messages_from_your_code#3665947)
+protocol TelemetryEvent {
+    var category: String { get }
+    var name: String { get }
+    var context: Context { get }
+    var logLevel: OSLogType { get }
+
+    func message() -> String
+}
+
+protocol TelemetryObserver {
+    /// Called every time an event with debug level
+    /// equal or greater than current occur.
+    func eventDidOccur<E: TelemetryEvent>(_ event: E)
+}
+

--- a/DecideTesting/SetValue+Environment.swift
+++ b/DecideTesting/SetValue+Environment.swift
@@ -13,11 +13,13 @@
 //===----------------------------------------------------------------------===//
 
 @testable import Decide
+import OSLog
 
 public extension ApplicationEnvironment {
     /// Set value at ``Mutable`` KeyPath on ``AtomicState``.
     func setValue<S: AtomicState, Value>(_ newValue: Value, _ keyPath: KeyPath<S, Mutable<Value>>) {
         setValue(newValue, keyPath.appending(path: \.wrappedValue))
+        telemetry.log(event: TestingMutation(context: .init(), keyPath: "\(keyPath)", value: newValue))
     }
 
     /// Set value at ``Mutable`` KeyPath on ``AtomicState``.
@@ -27,5 +29,27 @@ public extension ApplicationEnvironment {
         at identifier: I
     ) {
         setValue(newValue, keyPath.appending(path: \.wrappedValue), at: identifier)
+        telemetry.log(event: TestingMutation(context: .init(), keyPath: "\(keyPath):\(identifier)", value: newValue))
+    }
+}
+
+
+final class TestingMutation<V>: TelemetryEvent {
+    let category: String = "Testing: State Mutation"
+    let name: String = "Property updated:"
+    let logLevel: OSLogType = .debug
+    let context: Decide.Context
+
+    let keyPath: String
+    let value: V
+
+    init(context: Decide.Context, keyPath: String, value: V) {
+        self.keyPath = keyPath
+        self.context = context
+        self.value = value
+    }
+
+    func message() -> String {
+        "\(keyPath) -> \(String(reflecting: value))"
     }
 }


### PR DESCRIPTION
I'd like to opt in fully to OSLog, but then we can't attach these tracing to the crashes till iOS 15, at least not as easy.

So here's the draft how we can abstract it so we can improve it later.

Here's log sample:

```sh
2023-08-17 13:20:47.601482+0200 xctest[47898:2081394] [Unstructured State Mutation] Property updated:: \State.$strMutable.wrappedValue:100 -> "test_Observation_BindSet()-modified"
 context: Decide_Tests/KeyedState_Tests.swift:57
2023-08-17 13:20:47.602549+0200 xctest[47898:2081394] [Testing: State Mutation] Property updated:: \State.$strMutable:81 -> "test_Observation()-modified"
 context: DecideTesting/SetValue+Environment.swift:32
2023-08-17 13:20:47.602592+0200 xctest[47898:2081394] [Testing: State Mutation] Property updated:: \State.$strMutable:81 -> "test_Observation()-modified"
 context: DecideTesting/SetValue+Environment.swift:32
2023-08-17 13:20:47.603405+0200 xctest[47898:2081394] [Testing: State Mutation] Property updated:: \State.$strMutable:1 -> "test_SetValue()-modified"
 context: DecideTesting/SetValue+Environment.swift:32
```