### PR TITLE
Clean up generics

### DIFF
--- a/Decide/Accessor/Default/DefaultBind.swift
+++ b/Decide/Accessor/Default/DefaultBind.swift
@@ -14,16 +14,15 @@
 
 import Foundation
 
-/// 
 @propertyWrapper
-@MainActor public struct DefaultBind<S: AtomicState, Value> {
+@MainActor public struct DefaultBind<State: AtomicState, Value> {
     @DefaultEnvironment var environment
 
-    private let propertyKeyPath: KeyPath<S, Property<Value>>
+    private let propertyKeyPath: KeyPath<State, Property<Value>>
     let context: Context
 
     public init(
-        _ keyPath: KeyPath<S, Mutable<Value>>,
+        _ keyPath: KeyPath<State, Mutable<Value>>,
         file: String = #fileID,
         line: Int = #line
     ) {

--- a/Decide/Accessor/Default/DefaultBindKeyed.swift
+++ b/Decide/Accessor/Default/DefaultBindKeyed.swift
@@ -66,15 +66,15 @@ import Foundation
     }
 }
 
-@MainActor public struct KeyedValueBinding<I: Hashable, S: KeyedState<I>, Value> {
+@MainActor public struct KeyedValueBinding<Identifier: Hashable, State: KeyedState<Identifier>, Value> {
     unowned var environment: ApplicationEnvironment
 
     let observer: Observer
-    let propertyKeyPath: KeyPath<S, Property<Value>>
+    let propertyKeyPath: KeyPath<State, Property<Value>>
     let context: Context
 
     init(
-        bind propertyKeyPath: KeyPath<S, Property<Value>>,
+        bind propertyKeyPath: KeyPath<State, Property<Value>>,
         observer: Observer,
         environment: ApplicationEnvironment,
         context: Context
@@ -85,7 +85,7 @@ import Foundation
         self.environment = environment
     }
 
-    public subscript(_ identifier: I) -> Value {
+    public subscript(_ identifier: Identifier) -> Value {
         get {
             environment.subscribe(observer, on: propertyKeyPath, at: identifier)
             return environment.getValue(propertyKeyPath, at: identifier)

--- a/Decide/Accessor/Default/DefaultBindKeyed.swift
+++ b/Decide/Accessor/Default/DefaultBindKeyed.swift
@@ -16,15 +16,15 @@ import Foundation
 
 /// 
 @propertyWrapper
-@MainActor public struct DefaultBindKeyed<I: Hashable, S: KeyedState<I>, Value> {
+@MainActor public struct DefaultBindKeyed<Identifier: Hashable, State: KeyedState<Identifier>, Value> {
     @DefaultEnvironment var environment
 
-    private let propertyKeyPath: KeyPath<S, Property<Value>>
-    private var valueBinding: KeyedValueBinding<I, S, Value>?
+    private let propertyKeyPath: KeyPath<State, Property<Value>>
+    private var valueBinding: KeyedValueBinding<Identifier, State, Value>?
     let context: Context
 
     public init(
-        _ keyPath: KeyPath<S, Mutable<Value>>,
+        _ keyPath: KeyPath<State, Mutable<Value>>,
         file: String = #fileID,
         line: Int = #line
     ) {
@@ -35,9 +35,9 @@ import Foundation
 
     public static subscript<EnclosingObject: EnvironmentObservingObject>(
         _enclosingInstance instance: EnclosingObject,
-        wrapped wrappedKeyPath: KeyPath<EnclosingObject, KeyedValueBinding<I, S, Value>>,
+        wrapped wrappedKeyPath: KeyPath<EnclosingObject, KeyedValueBinding<Identifier, State, Value>>,
         storage storageKeyPath: WritableKeyPath<EnclosingObject, Self>
-    ) -> KeyedValueBinding<I, S, Value> {
+    ) -> KeyedValueBinding<Identifier, State, Value> {
         get {
             var storage = instance[keyPath: storageKeyPath]
             let propertyKeyPath = storage.propertyKeyPath
@@ -60,7 +60,7 @@ import Foundation
     public var projectedValue: Self { self }
 
     @available(*, unavailable, message: "@DefaultBind can only be enclosed by EnvironmentObservingObject.")
-    public var wrappedValue: KeyedValueBinding<I, S, Value> {
+    public var wrappedValue: KeyedValueBinding<Identifier, State, Value> {
         get { fatalError() }
         set { fatalError() }
     }

--- a/Decide/Accessor/Default/DefaultObserve.swift
+++ b/Decide/Accessor/Default/DefaultObserve.swift
@@ -17,18 +17,18 @@ import Foundation
 
 ///
 @propertyWrapper
-@MainActor public struct DefaultObserve<S: AtomicState, Value> {
+@MainActor public struct DefaultObserve<State: AtomicState, Value> {
     @DefaultEnvironment var environment
 
-    private let propertyKeyPath: KeyPath<S, Property<Value>>
+    private let propertyKeyPath: KeyPath<State, Property<Value>>
 
-    public init(_ keyPath: KeyPath<S, Property<Value>>) {
+    public init(_ keyPath: KeyPath<State, Property<Value>>) {
         self.propertyKeyPath = keyPath
     }
 
-    public init<P: PropertyModifier>(
-        _ keyPath: KeyPath<S, P>
-    ) where P.Value == Value {
+    public init<WrappedProperty: PropertyModifier>(
+        _ keyPath: KeyPath<State, WrappedProperty>
+    ) where WrappedProperty.Value == Value {
         propertyKeyPath = keyPath.appending(path: \.wrappedValue)
     }
 

--- a/Decide/Accessor/Default/DefaultObserveKeyed.swift
+++ b/Decide/Accessor/Default/DefaultObserveKeyed.swift
@@ -17,32 +17,32 @@ import Foundation
 /// 
 @propertyWrapper
 @MainActor public struct DefaultObserveKeyed<
-    I: Hashable,
-    S: KeyedState<I>,
+    Identifier: Hashable,
+    State: KeyedState<Identifier>,
     Value
 > {
     @DefaultEnvironment var environment
 
-    private let propertyKeyPath: KeyPath<S, Property<Value>>
-    private var valueObserve: KeyedValueObserve<I, S, Value>?
+    private let propertyKeyPath: KeyPath<State, Property<Value>>
+    private var valueObserve: KeyedValueObserve<Identifier, State, Value>?
 
     public init(
-        _ keyPath: KeyPath<S, Property<Value>>
+        _ keyPath: KeyPath<State, Property<Value>>
     ) {
         propertyKeyPath = keyPath
     }
 
     public init<P: PropertyModifier>(
-        _ keyPath: KeyPath<S, P>
+        _ keyPath: KeyPath<State, P>
     ) where P.Value == Value {
         propertyKeyPath = keyPath.appending(path: \.wrappedValue)
     }
 
     public static subscript<EnclosingObject: EnvironmentObservingObject>(
         _enclosingInstance instance: EnclosingObject,
-        wrapped wrappedKeyPath: KeyPath<EnclosingObject, KeyedValueObserve<I, S, Value>>,
+        wrapped wrappedKeyPath: KeyPath<EnclosingObject, KeyedValueObserve<Identifier, State, Value>>,
         storage storageKeyPath: WritableKeyPath<EnclosingObject, Self>
-    ) -> KeyedValueObserve<I, S, Value> {
+    ) -> KeyedValueObserve<Identifier, State, Value> {
         get {
             var storage = instance[keyPath: storageKeyPath]
             let propertyKeyPath = storage.propertyKeyPath
@@ -50,7 +50,7 @@ import Foundation
             storage.environment = environment
             let observer = Observer(instance)
             if storage.valueObserve == nil {
-                storage.valueObserve = KeyedValueObserve<I, S, Value>(
+                storage.valueObserve = KeyedValueObserve<Identifier, State, Value>(
                     bind: propertyKeyPath,
                     observer: observer,
                     environment: environment
@@ -64,7 +64,7 @@ import Foundation
     public var projectedValue: Self { self }
 
     @available(*, unavailable, message: "@DefaultBind can only be enclosed by EnvironmentObservingObject.")
-    public var wrappedValue: KeyedValueObserve<I, S, Value> {
+    public var wrappedValue: KeyedValueObserve<Identifier, State, Value> {
         get { fatalError() }
         set { fatalError() }
     }

--- a/Decide/Accessor/Default/DefaultObserveKeyed.swift
+++ b/Decide/Accessor/Default/DefaultObserveKeyed.swift
@@ -32,9 +32,9 @@ import Foundation
         propertyKeyPath = keyPath
     }
 
-    public init<P: PropertyModifier>(
-        _ keyPath: KeyPath<State, P>
-    ) where P.Value == Value {
+    public init<WrappedProperty: PropertyModifier>(
+        _ keyPath: KeyPath<State, WrappedProperty>
+    ) where WrappedProperty.Value == Value {
         propertyKeyPath = keyPath.appending(path: \.wrappedValue)
     }
 

--- a/Decide/Accessor/Default/DefaultObserveKeyed.swift
+++ b/Decide/Accessor/Default/DefaultObserveKeyed.swift
@@ -70,14 +70,14 @@ import Foundation
     }
 }
 
-@MainActor public struct KeyedValueObserve<I: Hashable, S: KeyedState<I>, Value> {
+@MainActor public struct KeyedValueObserve<Identifier: Hashable, State: KeyedState<Identifier>, Value> {
     unowned var environment: ApplicationEnvironment
 
     let observer: Observer
-    let propertyKeyPath: KeyPath<S, Property<Value>>
+    let propertyKeyPath: KeyPath<State, Property<Value>>
 
     init(
-        bind propertyKeyPath: KeyPath<S, Property<Value>>,
+        bind propertyKeyPath: KeyPath<State, Property<Value>>,
         observer: Observer,
         environment: ApplicationEnvironment
     ) {
@@ -86,7 +86,7 @@ import Foundation
         self.environment = environment
     }
 
-    public subscript(_ identifier: I) -> Value {
+    public subscript(_ identifier: Identifier) -> Value {
         get {
             environment.subscribe(observer, on: propertyKeyPath, at: identifier)
             return environment.getValue(propertyKeyPath, at: identifier)

--- a/Decide/Accessor/Instance.swift
+++ b/Decide/Accessor/Instance.swift
@@ -44,10 +44,10 @@ import SwiftUI
 }
 
 extension ApplicationEnvironment {
-    func defaultInstance<S: AtomicState, O>(
-        at keyPath: KeyPath<S, DefaultInstance<O>>
-    ) -> DefaultInstance<O> {
-        let storage: S = self[S.key()]
+    func defaultInstance<State: AtomicState, Object>(
+        at keyPath: KeyPath<State, DefaultInstance<Object>>
+    ) -> DefaultInstance<Object> {
+        let storage: State = self[State.key()]
         return storage[keyPath: keyPath]
     }
 }

--- a/Decide/Accessor/Instance.swift
+++ b/Decide/Accessor/Instance.swift
@@ -14,21 +14,21 @@
 import SwiftUI
 
 @propertyWrapper
-@MainActor public struct Instance<S: AtomicState, O> {
+@MainActor public struct Instance<State: AtomicState, Object> {
 
-    public typealias PropertyKeyPath = KeyPath<S, DefaultInstance<O>>
+    public typealias PropertyKeyPath = KeyPath<State, DefaultInstance<Object>>
 
     private let instanceKeyPath: PropertyKeyPath
 
-    public init(_ keyPath: KeyPath<S, DefaultInstance<O>>) {
+    public init(_ keyPath: KeyPath<State, DefaultInstance<Object>>) {
         self.instanceKeyPath = keyPath
     }
 
     public static subscript<EnclosingObject: EnvironmentManagedObject>(
         _enclosingInstance instance: EnclosingObject,
-        wrapped wrappedKeyPath: KeyPath<EnclosingObject, O>,
+        wrapped wrappedKeyPath: KeyPath<EnclosingObject, Object>,
         storage storageKeyPath: KeyPath<EnclosingObject, Self>
-    ) -> O {
+    ) -> Object {
         get {
             let storage = instance[keyPath: storageKeyPath]
             let instanceKeyPath = storage.instanceKeyPath
@@ -38,7 +38,7 @@ import SwiftUI
     }
 
     @available(*, unavailable, message: "@Instance must be enclosed in EnvironmentManagedObject.")
-    public var wrappedValue: O {
+    public var wrappedValue: Object {
         get { fatalError() }
     }
 }

--- a/Decide/Accessor/SwiftUI/Bind.swift
+++ b/Decide/Accessor/SwiftUI/Bind.swift
@@ -17,14 +17,18 @@ import SwiftUI
 
 /// **SwiftUI** property wrapper that provides two-way access to the value by ``Property`` KeyPath on ``AtomicState``from the view environment.
 @propertyWrapper
-@MainActor public struct Bind<S: AtomicState, Value>: DynamicProperty {
+@MainActor public struct Bind<State: AtomicState, Value>: DynamicProperty {
     @SwiftUI.Environment(\.stateEnvironment) var environment
     @ObservedObject var observer = ObservedObjectWillChangeNotification()
     let context: Context
 
-    let propertyKeyPath: KeyPath<S, Property<Value>>
+    let propertyKeyPath: KeyPath<State, Property<Value>>
 
-    public init(_ propertyKeyPath: KeyPath<S, Mutable<Value>>, file: String = #fileID, line: Int = #line) {
+    public init(
+        _ propertyKeyPath: KeyPath<State, Mutable<Value>>,
+        file: String = #fileID,
+        line: Int = #line
+    ) {
         let context = Context(file: file, line: line)
         self.context = context
         self.propertyKeyPath = propertyKeyPath.appending(path: \.wrappedValue)

--- a/Decide/Accessor/SwiftUI/BindKeyed.swift
+++ b/Decide/Accessor/SwiftUI/BindKeyed.swift
@@ -16,22 +16,22 @@ import SwiftUI
 
 /// **SwiftUI** property wrapper that provides two-way access to the value by ``Property`` KeyPath and a Key on ``KeyedState`` from the view environment.
 @propertyWrapper
-@MainActor public struct BindKeyed<I: Hashable, S: KeyedState<I>, Value>: DynamicProperty {
+@MainActor public struct BindKeyed<Identifier: Hashable, State: KeyedState<Identifier>, Value>: DynamicProperty {
 
     @SwiftUI.Environment(\.stateEnvironment) var environment
     @ObservedObject var observer = ObservedObjectWillChangeNotification()
     let context: Context
 
 
-    let propertyKeyPath: KeyPath<S, Property<Value>>
+    let propertyKeyPath: KeyPath<State, Property<Value>>
 
-    public init(_ propertyKeyPath: KeyPath<S, Mutable<Value>>, file: String = #fileID, line: Int = #line) {
+    public init(_ propertyKeyPath: KeyPath<State, Mutable<Value>>, file: String = #fileID, line: Int = #line) {
         let context = Context(file: file, line: line)
         self.context = context
         self.propertyKeyPath = propertyKeyPath.appending(path: \.wrappedValue)
     }
 
-    public subscript(_ identifier: I) -> Binding<Value> {
+    public subscript(_ identifier: Identifier) -> Binding<Value> {
         Binding<Value>(
             get: {
                 environment.subscribe(
@@ -47,7 +47,7 @@ import SwiftUI
         )
     }
 
-    public subscript(_ identifier: I) -> Value {
+    public subscript(_ identifier: Identifier) -> Value {
         get {
             environment.subscribe(Observer(observer), on: propertyKeyPath, at: identifier)
             return environment.getValue(propertyKeyPath, at: identifier)

--- a/Decide/Accessor/SwiftUI/BindKeyed.swift
+++ b/Decide/Accessor/SwiftUI/BindKeyed.swift
@@ -25,7 +25,11 @@ import SwiftUI
 
     let propertyKeyPath: KeyPath<State, Property<Value>>
 
-    public init(_ propertyKeyPath: KeyPath<State, Mutable<Value>>, file: String = #fileID, line: Int = #line) {
+    public init(
+        _ propertyKeyPath: KeyPath<State, Mutable<Value>>,
+        file: String = #fileID,
+        line: Int = #line
+    ) {
         let context = Context(file: file, line: line)
         self.context = context
         self.propertyKeyPath = propertyKeyPath.appending(path: \.wrappedValue)

--- a/Decide/Accessor/SwiftUI/Observe.swift
+++ b/Decide/Accessor/SwiftUI/Observe.swift
@@ -17,18 +17,18 @@ import SwiftUI
 
 /// **SwiftUI** property wrapper that provides read only access to the value by ``Property`` KeyPath on ``AtomicState``from the view environment.
 @propertyWrapper
-@MainActor public struct Observe<S: AtomicState, Value>: DynamicProperty {
+@MainActor public struct Observe<State: AtomicState, Value>: DynamicProperty {
     @SwiftUI.Environment(\.stateEnvironment) var environment
     @ObservedObject var observer = ObservedObjectWillChangeNotification()
     
-    let propertyKeyPath: KeyPath<S, Property<Value>>
+    let propertyKeyPath: KeyPath<State, Property<Value>>
     
-    public init(_ propertyKeyPath: KeyPath<S, Property<Value>>) {
+    public init(_ propertyKeyPath: KeyPath<State, Property<Value>>) {
         self.propertyKeyPath = propertyKeyPath
     }
     
     public init<P: PropertyModifier>(
-        _ propertyKeyPath: KeyPath<S, P>
+        _ propertyKeyPath: KeyPath<State, P>
     ) where P.Value == Value {
         self.propertyKeyPath = propertyKeyPath.appending(path: \.wrappedValue)
     }

--- a/Decide/Accessor/SwiftUI/Observe.swift
+++ b/Decide/Accessor/SwiftUI/Observe.swift
@@ -27,9 +27,9 @@ import SwiftUI
         self.propertyKeyPath = propertyKeyPath
     }
     
-    public init<P: PropertyModifier>(
-        _ propertyKeyPath: KeyPath<State, P>
-    ) where P.Value == Value {
+    public init<WrappedProperty: PropertyModifier>(
+        _ propertyKeyPath: KeyPath<State, WrappedProperty>
+    ) where WrappedProperty.Value == Value {
         self.propertyKeyPath = propertyKeyPath.appending(path: \.wrappedValue)
     }
     

--- a/Decide/Accessor/SwiftUI/ObserveKeyed.swift
+++ b/Decide/Accessor/SwiftUI/ObserveKeyed.swift
@@ -17,27 +17,27 @@ import SwiftUI
 /// **SwiftUI** property wrapper that provides read only access to the value by ``Property`` KeyPath and a Key on ``KeyedState`` from the view environment.
 @propertyWrapper
 @MainActor public struct ObserveKeyed<
-    I: Hashable,
-    S: KeyedState<I>,
+    Identifier: Hashable,
+    State: KeyedState<Identifier>,
     Value
 >: DynamicProperty {
 
     @SwiftUI.Environment(\.stateEnvironment) var environment
     @ObservedObject var observer = ObservedObjectWillChangeNotification()
 
-    let propertyKeyPath: KeyPath<S, Property<Value>>
+    let propertyKeyPath: KeyPath<State, Property<Value>>
 
-    public init(_ propertyKeyPath: KeyPath<S, Property<Value>>) {
+    public init(_ propertyKeyPath: KeyPath<State, Property<Value>>) {
         self.propertyKeyPath = propertyKeyPath
     }
 
     public init<P: PropertyModifier>(
-        _ propertyKeyPath: KeyPath<S, P>
+        _ propertyKeyPath: KeyPath<State, P>
     ) where P.Value == Value {
         self.propertyKeyPath = propertyKeyPath.appending(path: \.wrappedValue)
     }
 
-    public subscript(_ identifier: I) -> Value {
+    public subscript(_ identifier: Identifier) -> Value {
         get {
             environment.subscribe(Observer(observer), on: propertyKeyPath, at: identifier)
             return environment.getValue(propertyKeyPath, at: identifier)

--- a/Decide/Accessor/SwiftUI/ObserveKeyed.swift
+++ b/Decide/Accessor/SwiftUI/ObserveKeyed.swift
@@ -31,9 +31,9 @@ import SwiftUI
         self.propertyKeyPath = propertyKeyPath
     }
 
-    public init<P: PropertyModifier>(
-        _ propertyKeyPath: KeyPath<State, P>
-    ) where P.Value == Value {
+    public init<WrappedProperty: PropertyModifier>(
+        _ propertyKeyPath: KeyPath<State, WrappedProperty>
+    ) where WrappedProperty.Value == Value {
         self.propertyKeyPath = propertyKeyPath.appending(path: \.wrappedValue)
     }
 

--- a/Decide/Container/AtomicState.swift
+++ b/Decide/Container/AtomicState.swift
@@ -40,17 +40,17 @@ extension ApplicationEnvironment {
     //===------------------------------------------------------------------===//
     // MARK: - Observability
     //===------------------------------------------------------------------===//
-    func notifyObservers<S: AtomicState, Value>(
-        _ keyPath: KeyPath<S, Property<Value>>
+    func notifyObservers<State: AtomicState, Value>(
+        _ keyPath: KeyPath<State, Property<Value>>
     ) {
         let observers = popObservers(keyPath)
         observers.forEach { $0.notify() }
     }
 
-    func popObservers<S: AtomicState, Value>(
-        _ keyPath: KeyPath<S, Property<Value>>
+    func popObservers<State: AtomicState, Value>(
+        _ keyPath: KeyPath<State, Property<Value>>
     ) -> Set<Observer> {
-        let storage: S = self[S.key()]
+        let storage: State = self[State.key()]
         return storage[keyPath: keyPath].valueContainer.observerStorage.popObservers()
     }
 
@@ -60,23 +60,23 @@ extension ApplicationEnvironment {
     //===------------------------------------------------------------------===//
 
     /// Subscribe ``Observer`` at ``Property`` KeyPath on ``AtomicState``.
-    func subscribe<S: AtomicState, Value>(
+    func subscribe<State: AtomicState, Value>(
         _ observer: Observer,
-        on keyPath: KeyPath<S, Property<Value>>
+        on keyPath: KeyPath<State, Property<Value>>
     ) {
-        let storage: S = self[S.key()]
+        let storage: State = self[State.key()]
         storage[keyPath: keyPath].projectedValue.valueContainer.observerStorage.subscribe(observer)
     }
 
     /// Get value at ``Property`` KeyPath on ``AtomicState``.
-    func getValue<S: AtomicState, Value>(_ keyPath: KeyPath<S, Property<Value>>) -> Value {
-        let storage: S = self[S.key()]
+    func getValue<State: AtomicState, Value>(_ keyPath: KeyPath<State, Property<Value>>) -> Value {
+        let storage: State = self[State.key()]
         return storage[keyPath: keyPath].wrappedValue
     }
 
     /// Set value at ``Property`` KeyPath on ``AtomicState``.
-    func setValue<S: AtomicState, Value>(_ newValue: Value, _ keyPath: KeyPath<S, Property<Value>>) {
-        let storage: S = self[S.key()]
+    func setValue<State: AtomicState, Value>(_ newValue: Value, _ keyPath: KeyPath<State, Property<Value>>) {
+        let storage: State = self[State.key()]
         storage[keyPath: keyPath].wrappedValue = newValue
         notifyObservers(keyPath)
     }

--- a/Decide/Container/DefaultInstance.swift
+++ b/Decide/Container/DefaultInstance.swift
@@ -16,8 +16,8 @@ import Foundation
 
 /// Managed by ``ApplicationEnvironment`` storage for objects, unlike ``Property`` it doesn't support mutation nor observation.
 @propertyWrapper
-@MainActor public final class DefaultInstance<O> {
-    public var wrappedValue: O {
+@MainActor public final class DefaultInstance<Object> {
+    public var wrappedValue: Object {
         get {
             if let storage { return storage }
             let newValue = defaultValue()
@@ -26,19 +26,19 @@ import Foundation
         }
     }
     
-    public var projectedValue: DefaultInstance<O> {
+    public var projectedValue: DefaultInstance<Object> {
         self
     }
     
-    public init(wrappedValue: @autoclosure @escaping () -> O, file: StaticString = #fileID, line: UInt = #line) {
+    public init(wrappedValue: @autoclosure @escaping () -> Object, file: StaticString = #fileID, line: UInt = #line) {
         self.defaultValue = wrappedValue
         self.file = file.description
         self.line = line
     }
     
     // MARK: - Value Storage
-    private var storage: O?
-    private let defaultValue: () -> O
+    private var storage: Object?
+    private let defaultValue: () -> Object
     
     // MARK: - Tracing
     let file: String

--- a/Decide/Container/KeyedState.swift
+++ b/Decide/Container/KeyedState.swift
@@ -35,9 +35,9 @@ extension ApplicationEnvironment {
     // MARK: - Observability
     //===------------------------------------------------------------------===//
    
-    func notifyObservers<I: Hashable, S: KeyedState<I>, Value>(
-        _ keyPath: KeyPath<S, Property<Value>>,
-        _ identifier: I
+    func notifyObservers<Identifier: Hashable, State: KeyedState<Identifier>, Value>(
+        _ keyPath: KeyPath<State, Property<Value>>,
+        _ identifier: Identifier
     ) {
         let observers = popObservers(keyPath, identifier)
         observers.forEach { $0.notify() }
@@ -56,31 +56,31 @@ extension ApplicationEnvironment {
     //===------------------------------------------------------------------===//
 
     /// Subscribe ``ObservableValue`` at ``Property`` KeyPath on ``KeyedState``.
-    func subscribe<I:Hashable, S: KeyedState<I>, Value>(
+    func subscribe<Identifier: Hashable, State: KeyedState<Identifier>, Value>(
         _ observer: Observer,
-        on keyPath: KeyPath<S, Property<Value>>,
-        at identifier: I
+        on keyPath: KeyPath<State, Property<Value>>,
+        at identifier: Identifier
     ) {
-        let storage: S = self[S.key(identifier)]
+        let storage: State = self[State.key(identifier)]
         storage[keyPath: keyPath].projectedValue.valueContainer.observerStorage.subscribe(observer)
     }
 
     /// Get value at ``Property`` KeyPath on ``KeyedState``.
-    func getValue<I:Hashable, S: KeyedState<I>, Value>(
-        _ keyPath: KeyPath<S, Property<Value>>,
-        at identifier: I
+    func getValue<Identifier: Hashable, State: KeyedState<Identifier>, Value>(
+        _ keyPath: KeyPath<State, Property<Value>>,
+        at identifier: Identifier
     ) -> Value {
-        let storage: S = self[S.key(identifier)]
+        let storage: State = self[State.key(identifier)]
         return storage[keyPath: keyPath].wrappedValue
     }
 
     /// Set value at ``Property`` KeyPath on ``KeyedState``.
-    func setValue<I:Hashable, S: KeyedState<I>, Value>(
+    func setValue<Identifier: Hashable, State: KeyedState<Identifier>, Value>(
         _ newValue: Value,
-        _ keyPath: KeyPath<S, Property<Value>>,
-        at identifier: I
+        _ keyPath: KeyPath<State, Property<Value>>,
+        at identifier: Identifier
     ) {
-        let storage: S = self[S.key(identifier)]
+        let storage: State = self[State.key(identifier)]
         storage[keyPath: keyPath].wrappedValue = newValue
         notifyObservers(keyPath, identifier)
     }

--- a/Decide/Environment/Environment.swift
+++ b/Decide/Environment/Environment.swift
@@ -44,9 +44,9 @@ import Foundation
         return Telemetry(observer: OSLogTelemetryObserver()) // .noTelemetry
     }()
 
-    subscript<S: ValueContainerStorage>(_ key: Key) -> S {
-        if let state = storage[key] as? S { return state }
-        let newValue = S.init()
+    subscript<Storage: ValueContainerStorage>(_ key: Key) -> Storage {
+        if let state = storage[key] as? Storage { return state }
+        let newValue = Storage.init()
         storage[key] = newValue
         return newValue
     }

--- a/Decide/Structured State Mutation/Decision.swift
+++ b/Decide/Structured State Mutation/Decision.swift
@@ -46,9 +46,9 @@ import Foundation
         }
     }
 
-    public subscript<ID:Hashable, State: KeyedState<ID>, Value>(
+    public subscript<Identifier: Hashable, State: KeyedState<Identifier>, Value>(
         _ propertyKeyPath: KeyPath<State, Property<Value>>,
-        at identifier: ID
+        at identifier: Identifier
     ) -> Value {
         get {
             environment.getValue(propertyKeyPath, at: identifier)
@@ -68,17 +68,17 @@ import Foundation
     }
 
     /// Set value at ``Property`` KeyPath on ``KeyedState``.
-    func setValue<ID:Hashable, State: KeyedState<ID>, Value>(
+    func setValue<Identifier: Hashable, State: KeyedState<Identifier>, Value>(
         _ keyPath: KeyPath<State, Property<Value>>,
         _ newValue: Value,
-        at identifier: ID
+        at identifier: Identifier
     ) {
         transactions.insert(
             Transaction(keyPath, newValue: newValue, at: identifier)
         )
     }
 
-    public func perform<E: Effect>(effect: E) {
+    public func perform<SideEffect: Effect>(effect: SideEffect) {
         effects.append(effect)
     }
 }

--- a/Decide/Structured State Mutation/Effect.swift
+++ b/Decide/Structured State Mutation/Effect.swift
@@ -28,30 +28,30 @@ public protocol Effect: Actor {
         self.environment = environment
     }
 
-    public subscript<S: AtomicState, V>(_ propertyKeyPath: KeyPath<S, Property<V>>) -> V {
+    public subscript<State: AtomicState, Value>(_ propertyKeyPath: KeyPath<State, Property<Value>>) -> Value {
         get { environment.getValue(propertyKeyPath) }
     }
 
-    public subscript<I, S, V>(
-        _ propertyKeyPath: KeyPath<S, Property<V>>,
-        at identifier: I
-    ) -> V
-    where I: Hashable, S: KeyedState<I>
+    public subscript<Identifier, State, Value>(
+        _ propertyKeyPath: KeyPath<State, Property<Value>>,
+        at identifier: Identifier
+    ) -> Value
+    where Identifier: Hashable, State: KeyedState<Identifier>
     {
         get { environment.getValue(propertyKeyPath, at: identifier) }
     }
 
-    public subscript<S: AtomicState, V>(_ propertyKeyPath: KeyPath<S, Mutable<V>>) -> V {
+    public subscript<State: AtomicState, Value>(_ propertyKeyPath: KeyPath<State, Mutable<Value>>) -> Value {
         get {
             environment.getValue(propertyKeyPath.appending(path: \.wrappedValue))
         }
     }
 
-    public subscript<I, S, V>(
-        _ propertyKeyPath: KeyPath<S, Mutable<V>>,
-        at identifier: I
-    ) -> V
-    where I: Hashable, S: KeyedState<I>
+    public subscript<Identifier, State, Value>(
+        _ propertyKeyPath: KeyPath<State, Mutable<Value>>,
+        at identifier: Identifier
+    ) -> Value
+    where Identifier: Hashable, State: KeyedState<Identifier>
     {
         get {
             environment.getValue(propertyKeyPath.appending(path: \.wrappedValue), at: identifier)
@@ -63,14 +63,14 @@ public protocol Effect: Actor {
         await environment.makeAwaiting(decision: decision)
     }
 
-    @MainActor public func instance<S: AtomicState, O>(_ keyPath: KeyPath<S, DefaultInstance<O>>) -> O {
-        let obj = environment.defaultInstance(at: keyPath).wrappedValue
-        return obj
+    @MainActor public func instance<State: AtomicState, Object>(_ keyPath: KeyPath<State, DefaultInstance<Object>>) -> Object {
+        let object = environment.defaultInstance(at: keyPath).wrappedValue
+        return object
     }
 
-    @MainActor public func instance<S: AtomicState, O: EnvironmentManagedObject>(_ keyPath: KeyPath<S, DefaultInstance<O>>) -> O {
-        let obj = environment.defaultInstance(at: keyPath).wrappedValue
-        obj.environment = self.environment
-        return obj
+    @MainActor public func instance<State: AtomicState, Object: EnvironmentManagedObject>(_ keyPath: KeyPath<State, DefaultInstance<Object>>) -> Object {
+        let object = environment.defaultInstance(at: keyPath).wrappedValue
+        object.environment = self.environment
+        return object
     }
 }

--- a/Decide/Structured State Mutation/Transaction.swift
+++ b/Decide/Structured State Mutation/Transaction.swift
@@ -49,10 +49,10 @@ final class Transaction: Hashable {
         self.identity = propertyKeyPath
     }
 
-    @MainActor init<ID:Hashable, State: KeyedState<ID>, Value>(
+    @MainActor init<Identifier: Hashable, State: KeyedState<Identifier>, Value>(
         _ propertyKeyPath: KeyPath<State, Property<Value>>,
         newValue: Value,
-        at identifier: ID
+        at identifier: Identifier
     ) {
         self.mutate = { environment in
             environment.setValue(newValue, propertyKeyPath, at: identifier)

--- a/Decide/Telemetry/Events/UnstructuredMutation.swift
+++ b/Decide/Telemetry/Events/UnstructuredMutation.swift
@@ -14,16 +14,16 @@
 
 import OSLog
 
-final class UnstructuredMutation<V>: TelemetryEvent {
+final class UnstructuredMutation<Value>: TelemetryEvent {
     let category: String = "Unstructured State Mutation"
     let name: String = "Property updated:"
     let logLevel: OSLogType = .debug
     let context: Decide.Context
 
     let keyPath: String
-    let value: V
+    let value: Value
 
-    init(context: Decide.Context, keyPath: String, value: V) {
+    init(context: Decide.Context, keyPath: String, value: Value) {
         self.keyPath = keyPath
         self.context = context
         self.value = value

--- a/Decide/Telemetry/LoggerObserver.swift
+++ b/Decide/Telemetry/LoggerObserver.swift
@@ -41,7 +41,7 @@ final class OSLogTelemetryObserver: TelemetryObserver {
         return false
     }()
 
-    func eventDidOccur<E>(_ event: E) where E : TelemetryEvent {
+    func eventDidOccur<Event>(_ event: Event) where Event: TelemetryEvent {
         let logger = Logger(subsystem: Self.subsystem, category: event.category)
         if Self.unsafeTracingEnabled {
             unsafeTrace(event: event, logger: logger)
@@ -51,7 +51,7 @@ final class OSLogTelemetryObserver: TelemetryObserver {
 
     }
 
-    func trace<E>(event: E, logger: Logger) where E : TelemetryEvent {
+    func trace<Event>(event: Event, logger: Logger) where Event: TelemetryEvent {
         switch event.logLevel {
         case .debug:
             logger.debug("\(event.name): \(event.message(), privacy: .sensitive)\n context: \(event.context.debugDescription)")
@@ -66,7 +66,7 @@ final class OSLogTelemetryObserver: TelemetryObserver {
         }
     }
 
-    func unsafeTrace<E>(event: E, logger: Logger) where E : TelemetryEvent {
+    func unsafeTrace<Event>(event: Event, logger: Logger) where Event: TelemetryEvent {
         switch event.logLevel {
         case .debug:
             logger.debug("\(event.name): \(event.message(), privacy: .sensitive)\n context: \(event.context.debugDescription)")

--- a/Decide/Telemetry/Telemetry.swift
+++ b/Decide/Telemetry/Telemetry.swift
@@ -27,7 +27,7 @@ final class Telemetry {
         self.observer = observer
     }
 
-    func log<E: TelemetryEvent>(event: E) {
+    func log<Event: TelemetryEvent>(event: Event) {
         guard event.logLevel.rawValue >= self.logLevel.rawValue
         else { return }
         observer.eventDidOccur(event)
@@ -35,7 +35,7 @@ final class Telemetry {
 }
 
 final class DoNotObserve: TelemetryObserver {
-    func eventDidOccur<E>(_ event: E) where E : TelemetryEvent {}
+    func eventDidOccur<Event>(_ event: Event) where Event : TelemetryEvent {}
 }
 extension Telemetry {
     static let noTelemetry = Telemetry(observer: DoNotObserve())
@@ -54,6 +54,6 @@ protocol TelemetryEvent {
 protocol TelemetryObserver {
     /// Called every time an event with debug level
     /// equal or greater than current occur.
-    func eventDidOccur<E: TelemetryEvent>(_ event: E)
+    func eventDidOccur<Event: TelemetryEvent>(_ event: Event)
 }
 

--- a/DecideTesting/AssertValueAt.swift
+++ b/DecideTesting/AssertValueAt.swift
@@ -21,9 +21,9 @@ public extension ApplicationEnvironment {
     //===------------------------------------------------------------------===//
 
     /// Asserts that value of given container is equal to given value.
-    func AssertValueIn<V: Equatable>(
-        _ valueA: V,
-        isEqual valueB: V,
+    func AssertValueIn<Value: Equatable>(
+        _ valueA: Value,
+        isEqual valueB: Value,
         file: StaticString = #file,
         line: UInt = #line
     ) {
@@ -37,46 +37,46 @@ public extension ApplicationEnvironment {
 
     /// Asserts that value at given KeyPath is equal to given value.
     func AssertValueAt<
-        P: PropertyModifier,
-        V: Equatable,
-        S: AtomicState
-    > (
-        _ keyPath: KeyPath<S, P>,
-        isEqual value: V,
+        WrappedProperty: PropertyModifier,
+        Value: Equatable,
+        State: AtomicState
+    >(
+        _ keyPath: KeyPath<State, WrappedProperty>,
+        isEqual value: Value,
         file: StaticString = #file,
         line: UInt = #line
-    ) where P.Value == V {
+    ) where WrappedProperty.Value == Value {
         let containerValue = getValue(keyPath.appending(path: \.wrappedValue))
         AssertValueIn(containerValue, isEqual: value, file: file, line: line)
     }
 
     /// Asserts that value at given KeyPath is equal to given value.
     func AssertValueAt<
-        V: Equatable,
-        S: AtomicState
+        Value: Equatable,
+        State: AtomicState
     >(
-        _ keyPath: KeyPath<S, Property<V>>,
-        isEqual value: V,
+        _ keyPath: KeyPath<State, Property<Value>>,
+        isEqual value: Value,
         file: StaticString = #file,
         line: UInt = #line
     ) {
         let containerValue = getValue(keyPath)
         AssertValueIn(containerValue, isEqual: value, file: file, line: line)
     }
-    
+
     //===------------------------------------------------------------------===//
     // MARK: - Keyed
     //===------------------------------------------------------------------===//
 
     /// Asserts that value of given container and Identifier is equal to given value.
     func AssertValueIn<
-        V: Equatable,
-        I: Hashable,
-        S: KeyedState<I>
+        Value: Equatable,
+        Identifier: Hashable,
+        State: KeyedState<Identifier>
     >(
-        _ valueA: V,
-        identifier: I,
-        isEqual valueB: V,
+        _ valueA: Value,
+        identifier: Identifier,
+        isEqual valueB: Value,
         file: StaticString = #file,
         line: UInt = #line
     ) {
@@ -89,30 +89,30 @@ public extension ApplicationEnvironment {
 
     /// Asserts that value at given KeyPath and Identifier is equal to given value.
     func AssertValueAt<
-        P: PropertyModifier,
-        V: Equatable,
-        I: Hashable,
-        S: KeyedState<I>
+        WrappedProperty: PropertyModifier,
+        Value: Equatable,
+        Identifier: Hashable,
+        State: KeyedState<Identifier>
     >(
-        _ keyPath: KeyPath<S, P>,
-        at identifier: I,
-        isEqual value: V,
+        _ keyPath: KeyPath<State, WrappedProperty>,
+        at identifier: Identifier,
+        isEqual value: Value,
         file: StaticString = #file,
         line: UInt = #line
-    ) where P.Value == V {
+    ) where WrappedProperty.Value == Value {
         let containerValue = getValue(keyPath.appending(path: \.wrappedValue), at: identifier)
         AssertValueIn(containerValue, identifier: identifier, isEqual: value, file: file, line: line)
     }
 
     /// Asserts that value at given KeyPath and Identifier is equal to given value.
     func AssertValueAt<
-        V: Equatable,
-        I: Hashable,
-        S: KeyedState<I>
+        Value: Equatable,
+        Identifier: Hashable,
+        State: KeyedState<Identifier>
     >(
-        _ keyPath: KeyPath<S, Property<V>>,
-        at identifier: I,
-        isEqual value: V,
+        _ keyPath: KeyPath<State, Property<Value>>,
+        at identifier: Identifier,
+        isEqual value: Value,
         file: StaticString = #file,
         line: UInt = #line
     ) {

--- a/DecideTesting/Mirror+EnvironmentOverride.swift
+++ b/DecideTesting/Mirror+EnvironmentOverride.swift
@@ -14,7 +14,10 @@
 
 import Decide
 
-@MainActor public func WithEnvironment<T>(_ environment: ApplicationEnvironment, object: T) -> T {
+@MainActor public func WithEnvironment<Object>(
+    _ environment: ApplicationEnvironment,
+    object: Object
+) -> Object {
     Mirror(reflecting: object).replaceEnvironment(with: environment)
     return object
 }
@@ -27,12 +30,12 @@ private extension Mirror {
     }
 
     @MainActor func replaceEnvironment(on child: inout Mirror.Child, with newEnvironment: ApplicationEnvironment) {
-        if let obj = child.value as? DefaultEnvironment {
-            obj.wrappedValue = newEnvironment
+        if let object = child.value as? DefaultEnvironment {
+            object.wrappedValue = newEnvironment
             return
         }
 
-        let m = Mirror(reflecting: child.value)
-        m.replaceEnvironment(with: newEnvironment)
+        let mirror = Mirror(reflecting: child.value)
+        mirror.replaceEnvironment(with: newEnvironment)
     }
 }

--- a/DecideTesting/SetValue+Environment.swift
+++ b/DecideTesting/SetValue+Environment.swift
@@ -17,16 +17,19 @@ import OSLog
 
 public extension ApplicationEnvironment {
     /// Set value at ``Mutable`` KeyPath on ``AtomicState``.
-    func setValue<S: AtomicState, Value>(_ newValue: Value, _ keyPath: KeyPath<S, Mutable<Value>>) {
+    func setValue<State: AtomicState, Value>(
+        _ newValue: Value,
+        _ keyPath: KeyPath<State, Mutable<Value>>
+    ) {
         setValue(newValue, keyPath.appending(path: \.wrappedValue))
         telemetry.log(event: TestingMutation(context: .init(), keyPath: "\(keyPath)", value: newValue))
     }
 
     /// Set value at ``Mutable`` KeyPath on ``AtomicState``.
-    func setValue<I:Hashable, S: KeyedState<I>, Value>(
+    func setValue<Identifier: Hashable, State: KeyedState<Identifier>, Value>(
         _ newValue: Value,
-        _ keyPath: KeyPath<S, Mutable<Value>>,
-        at identifier: I
+        _ keyPath: KeyPath<State, Mutable<Value>>,
+        at identifier: Identifier
     ) {
         setValue(newValue, keyPath.appending(path: \.wrappedValue), at: identifier)
         telemetry.log(event: TestingMutation(context: .init(), keyPath: "\(keyPath):\(identifier)", value: newValue))
@@ -34,16 +37,16 @@ public extension ApplicationEnvironment {
 }
 
 
-final class TestingMutation<V>: TelemetryEvent {
+final class TestingMutation<Value>: TelemetryEvent {
     let category: String = "Testing: State Mutation"
     let name: String = "Property updated:"
     let logLevel: OSLogType = .debug
     let context: Decide.Context
 
     let keyPath: String
-    let value: V
+    let value: Value
 
-    init(context: Decide.Context, keyPath: String, value: V) {
+    init(context: Decide.Context, keyPath: String, value: Value) {
         self.keyPath = keyPath
         self.context = context
         self.value = value


### PR DESCRIPTION
### Description

This PR cleans up the single character generics to make the library a little bit more readable. This is important because most objects are public facing API, and users of the API can with a glance get context of what is needed from them.

This PR goes through the whole library and updates all generics and tries to make it more consistent throughout.

In some places, I also refactor some functions and initializers to multiple lines to make the code a little bit more readable. What would be ideal is to have a tool like Swift format run as a Github action to make all contributions more consistent