### PR TITLE
Basic macro setup

### DIFF
--- a/.github/workflows/swift-build-test.yml
+++ b/.github/workflows/swift-build-test.yml
@@ -16,10 +16,9 @@ jobs:
   build:
     runs-on: macos-13
     steps:
-    steps:
     - uses: swift-actions/setup-swift@v1
       with:
-        swift-version: 5.9
+        swift-version: "5.9"
     - name: Get swift version
       run: swift --version
     - uses: actions/checkout@v3

--- a/.github/workflows/swift-build-test.yml
+++ b/.github/workflows/swift-build-test.yml
@@ -16,6 +16,12 @@ jobs:
   build:
     runs-on: macos-13
     steps:
+    steps:
+    - uses: swift-actions/setup-swift@v1
+      with:
+        swift-version: 5.9
+    - name: Get swift version
+      run: swift --version
     - uses: actions/checkout@v3
     - name: Build
       run: swift build -v

--- a/Decide/Macros.swift
+++ b/Decide/Macros.swift
@@ -1,0 +1,13 @@
+import DecideMacros
+
+@attached(
+    member,
+    names: named(environment),
+    named(init(environment:))
+)
+@attached(memberAttribute)
+@attached(extension, conformances: StateRoot)
+public macro EnvironmentObservable() = #externalMacro(
+    module: "DecideMacros",
+    type: "StorageMacro"
+)

--- a/DecideMacros-Tests/Decide_Tests.swift
+++ b/DecideMacros-Tests/Decide_Tests.swift
@@ -1,0 +1,12 @@
+import XCTest
+import Decide
+
+final class Decide_Tests: XCTestCase {
+    @EnvironmentObservable
+    final class Notes {
+        @Persistent
+        var name: String = ""
+        
+        var count: Int = 0
+    }
+}

--- a/DecideMacros/Plugin.swift
+++ b/DecideMacros/Plugin.swift
@@ -1,0 +1,12 @@
+#if canImport(SwiftCompilerPlugin)
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct DecideCompilerPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        StorageMacro.self,
+//        AtomicPropertyMacro.self,
+    ]
+}
+#endif

--- a/DecideMacros/StorageMacro.swift
+++ b/DecideMacros/StorageMacro.swift
@@ -1,0 +1,57 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public protocol ObservableState {
+    init()
+}
+
+public struct StorageMacro: MemberMacro, MemberAttributeMacro {
+    public static func expansion(
+        of node: SwiftSyntax.AttributeSyntax,
+        attachedTo declaration: some SwiftSyntax.DeclGroupSyntax,
+        providingAttributesFor member: some SwiftSyntax.DeclSyntaxProtocol,
+        in context: some SwiftSyntaxMacros.MacroExpansionContext
+    ) throws -> [SwiftSyntax.AttributeSyntax] {
+        return [
+            AttributeSyntax(
+                attributeName: IdentifierTypeSyntax(
+                    name: .identifier("ObservableValue")
+                )
+            )
+        ]
+    }
+
+    // MARK: - MemberMacro
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let _ = declaration.asProtocol(NamedDeclSyntax.self) else {
+            return []
+        }
+
+        let environment: DeclSyntax =
+      """
+      public unowned let environment: Decide.SharedEnvironment
+      public init(environment: Decide.SharedEnvironment) {
+        self.environment = environment
+      }
+      """
+
+        return [environment]
+    }
+}
+
+
+extension StorageMacro: ExtensionMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        [try ExtensionDeclSyntax("extension \(type): Decide.StateRoot {}")]
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Decide package open source project
-//b
+//
 // Copyright (c) 2020-2023 Maxim Bazarov and the Decide package
 // open source project authors
 // Licensed under MIT

--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,8 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Decide package open source project
-//
+//b
 // Copyright (c) 2020-2023 Maxim Bazarov and the Decide package
 // open source project authors
 // Licensed under MIT
@@ -14,6 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 import PackageDescription
+import CompilerPluginSupport
 
 let package = Package(
     name: "Decide",
@@ -28,13 +29,24 @@ let package = Package(
         .library(name: "DecideTesting", targets: ["DecideTesting"]),
     ],
     dependencies: [
+        // Depend on the Swift 5.9 release of SwiftSyntax
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
     ],
     targets: [
-        // - Decide -
         .target(
             name: "Decide",
-            dependencies: [],
+            dependencies: [
+                "DecideMacros"
+            ],
             path: "Decide"
+        ),
+        .macro(
+            name: "DecideMacros",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+            ],
+            path: "DecideMacros"
         ),
         .testTarget(
             name: "Decide-Tests",
@@ -49,6 +61,16 @@ let package = Package(
             name: "DecideTesting",
             dependencies: ["Decide"],
             path: "DecideTesting"
+        ),
+        // Macros Tests
+        .testTarget(
+            name: "DecideMacros-Tests",
+            dependencies: [
+                "Decide",
+                "DecideMacros",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+            ],
+            path: "DecideMacros-Tests"
         ),
     ]
 )


### PR DESCRIPTION
Introduces the first macro `@EnvironmentObservable` that removes code that is repeatable, and similar to swift `@Observable`

```swift 
@EnvironmentObservable
final class Notes {
    @Persistent
    var name: String = ""
    
    var count: Int = 0
}
```


will expand to:
<img width="734" alt="Screenshot 2023-12-31 at 13 57 02" src="https://github.com/MaximBazarov/Decide/assets/11208417/3f18a119-f2fb-44dd-afa9-2ba356771178">
